### PR TITLE
Added --no-opt options for revert (stash) and delete-key (trash)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+README.rst
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/quicksave/__main__.py
+++ b/quicksave/__main__.py
@@ -148,23 +148,22 @@ def main(args_input=sys.argv[1:]):
         help="The state key or alias to revert to."
     )
     revert_parser.add_argument(
-        '--no-stash',
-        action='store_false',
-        help="Do not save the state under the ~stash state key before reverting.\n"+
-        "This is the default if reverting to ~stash, but stashing is enabled in all other cases.\n"
-        "If the file's full sha-256 hash is currently registered as a state alias,\n"+
-        "then ~stash will simply alias this file's true state key.\n"+
-        "Otherwise, the full state will be saved under ~stash.\n"
-        "The ~stash state key should not be used for permanent storage as it may be frequently overwritten.\n"+
-        "To save the current ~stash state permanently, use \n"+
-        "'$ quicksave revert <filename> ~stash' then\n"+
-        "'$ quicksave save <filename>'",
+        '--stash',
+        action='store_true',
+        help="Save the current state of the file to ~stash. "
+        "This is the default except when reverting to ~stash",
         dest='stash'
+    )
+    revert_parser.add_argument(
+        '--no-stash',
+        action='store_true',
+        help="Opposite of --stash.  This is the default when reverting to ~stash",
+        dest='nstash'
     )
     revert_parser.add_argument(
         '-f', '--force',
         action='store_true',
-        help="Forces the revert to progress even if the file is already in the requested state"
+        help="Forces the revert even if the file is already in the requested state"
     )
 
     alias_parser = subparsers.add_parser(
@@ -247,17 +246,20 @@ def main(args_input=sys.argv[1:]):
         "This *MUST* be an authoritative key, and not an alias.  Aliases can be deleted using the 'alias' command"
     )
     delete_parser.add_argument(
-        '--no-save',
-        action='store_false',
-        help="By default, the most recently deleted file or state key is saved under the ~trash key\n"+
-        "(which is a reserved file key as well as a reserved state key under all file keys).\n"+
-        "Using the --no-save option disables this behavior, however the deleted key will be immediately and irrecoverably lost.\n"+
-        "~trash should not be used for permanent storage as it may be overwritten frequently.\n"+
-        "To recover the ~trash *FILE* key, use '$ quicksave recover'.\n"+
-        "To recover the ~trash *STATE* key, use\n"+
-        "'$ quicksave revert <filename> ~trash' then\n"+
-        "'$ quicksave save <filename>'.  Note that old aliases of the deleted state key will not be recovered, and must be set manually",
+        '--save', '--trash',
+        action='store_true',
+        help="Move the key and its data to ~trash instead of deleting. "
+        "Data can be recovered from the ~trash file key by using quicksave recover. "
+        "Data can be recovered from ~trash state keys by using quicksave revert. "
+        "Data in a ~trash key will be deleted and overwritten when another key is "
+        "deleted and saved to ~trash",
         dest='save'
+    )
+    delete_parser.add_argument(
+        '--no-save', '--no-trash',
+        action='store_true',
+        help="Opposite of --save.  Immediately and irrecoverably delete the key.",
+        dest='nsave'
     )
     delete_parser.add_argument(
         '-c', '--clean-aliases',

--- a/quicksave/__main__.py
+++ b/quicksave/__main__.py
@@ -233,6 +233,8 @@ def main(args_input=sys.argv[1:]):
     )
     delete_parser.set_defaults(func=commands.command_delete)
     helper['delete-key'] = delete_parser.print_help
+    helper['rm'] = delete_parser.print_help
+    helper['delete'] = delete_parser.print_help
     delete_parser.add_argument(
         'filekey',
         nargs='?',

--- a/quicksave/commands/command_clean.py
+++ b/quicksave/commands/command_clean.py
@@ -211,9 +211,9 @@ def command_clean(args, do_print):
         for filekey in duplicates:
             for hashkey in duplicates[filekey]:
                 if filekey+":"+hashkey not in utils._CURRENT_DATABASE.state_keys:
-                    utils._CURRENT_DATABASE.register_sa(filekey, duplicates[filekey][hashkey].replace(filekey+":", '', 1), hashkey)
+                    utils._CURRENT_DATABASE.register_sa(filekey, duplicates[filekey][hashkey].replace(filekey+":", '', 1), hashkey, overwrite=True)
                 if filekey+":"+hashkey[:7] not in utils._CURRENT_DATABASE.state_keys:
-                    utils._CURRENT_DATABASE.register_sa(filekey, duplicates[filekey][hashkey].replace(filekey+":", '', 1), hashkey[:7])
+                    utils._CURRENT_DATABASE.register_sa(filekey, duplicates[filekey][hashkey].replace(filekey+":", '', 1), hashkey[:7], overwrite=True)
         if len(forward):
             msg += "Removed the following %d duplicate state keys:%s and forwarded %d aliases\n"%(
                 len(forward),

--- a/quicksave/commands/command_delete.py
+++ b/quicksave/commands/command_delete.py
@@ -6,7 +6,7 @@ from .. import utils
 def command_delete(args, do_print):
     utils.initdb(do_print)
     didtrash = False
-    args.save = args.save and utils._checkflag('delete.trash', '1')=='1'
+    args.save = utils._check_action(args.save, args.nsave, 'delete.trash', '1')
     if not args.filekey:
         #when deleting a file key:
         #   - Remove the data folder for the current ~trash entry

--- a/quicksave/commands/command_revert.py
+++ b/quicksave/commands/command_revert.py
@@ -7,7 +7,7 @@ def command_revert(args, do_print):
     utils.initdb(do_print)
     infer = not bool(args.file_key)
     did_stash = False
-    args.stash = args.stash and utils._checkflag('revert.stash', '1')=='1'
+    args.stash = utils._check_action(args.stash, args.nstash, 'revert.stash', '1')
     if infer:
         filepath = os.path.abspath(args.filename.name)
         if utils._checkflag('inference.path', '1')=='1' and filepath in utils._CURRENT_DATABASE.file_keys:

--- a/quicksave/utils.py
+++ b/quicksave/utils.py
@@ -26,6 +26,13 @@ def _checkflag(flagname, default):
         return _FLAGS[flagname]
     return default
 
+def _check_action(yes, no, flag, default):
+    if yes:
+        return True
+    if no:
+        return False
+    return _checkflag(flag, default)=='1'
+
 def _loadflags(raw_reader):
     reader = csv.reader(raw_reader, delimiter='\t')
     for line in reader:

--- a/tests/test_quicksave.py
+++ b/tests/test_quicksave.py
@@ -477,11 +477,34 @@ class test(unittest.TestCase):
 
     def test_g_delete(self):
         from quicksave.__main__ import main
-
+        ## Test no-save option
+        tmp = open(os.path.join(self.test_directory.name, random_string(90)), 'w+b')
+        tmp.write(os.urandom(4096))
+        tmp.close()
+        filekey = main([
+            '--return-result',
+            'register',
+            tmp.name
+        ])[0]
         main([
             '--return-result',
             'delete-key',
-            DATA['temp-filekey']
+            filekey,
+            '--no-save'
+        ])
+        remaining = main([
+            '--return-result',
+            'list',
+            '-a'
+        ])
+        DATA['all-file-handles'] = [item for item in remaining]
+        self.assertFalse(filekey in remaining)
+        self.assertFalse('~trash' in remaining)
+        ## Test regular options
+        main([
+            '--return-result',
+            'delete-key',
+            DATA['temp-filekey'],
         ])
         remaining = main([
             '--return-result',
@@ -509,7 +532,6 @@ class test(unittest.TestCase):
                 'delete-key',
                 'Probably not a real key though'
             ])
-
         main([
             '--return-result',
             'delete-key',

--- a/tests/test_quicksave.py
+++ b/tests/test_quicksave.py
@@ -226,6 +226,40 @@ class test(unittest.TestCase):
             '-k',
             DATA['register-filekey']
         ])
+        with open(sourcefile.name, 'rb') as reader:
+            current = sha256(reader.read()).hexdigest()
+        desired = sha256(DATA['revert-content']).hexdigest()
+        self.assertEqual(current, desired)
+        initial = main([
+            '--return-result',
+            'lookup',
+            DATA['register-filekey'],
+            '~stash'
+        ])
+        main([
+            '--return-result',
+            'revert',
+            sourcefile.name,
+            DATA['save-statekey'],
+            '-k',
+            DATA['register-filekey'],
+            '--no-stash'
+        ])
+        final = main([
+            '--return-result',
+            'lookup',
+            DATA['register-filekey'],
+            '~stash'
+        ])
+        self.assertEqual(initial, final)
+        main([
+            '--return-result',
+            'revert',
+            sourcefile.name,
+            '~stash',
+            '-k',
+            DATA['register-filekey']
+        ])
 
     def test_e_alias(self):
         from quicksave.__main__ import main


### PR DESCRIPTION
Allows the user to always control behavior at runtime without having to change the config first.
Supported options are:
* `quicksave revert --[no-]stash` which corresponds to the configuration `revert.stash`
* `quicksave delete --[no-]save` or `--[no-]trash` which corresponds to the configuration `delete.trash`